### PR TITLE
Add content-type to client logResponse

### DIFF
--- a/src/clients/client.js
+++ b/src/clients/client.js
@@ -139,7 +139,12 @@ export default class Client extends EventEmitter {
         response.text().then((text) => {
           let result = text;
 
-          this.logResponse({ status: response.status, body: result, time: roundTripMs });
+          this.logResponse({
+            status: response.status,
+            body: result,
+            time: roundTripMs,
+            type: response.headers.get('content-type'),
+          });
 
           // Return JSON if text can parse as such
           try {


### PR DESCRIPTION
Add content-type (`type`) to logResponse output so as to be able to decide how to parse response.